### PR TITLE
feat(data): Hyperliquid REST/WS data layer + external prices

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "@nktkas/hyperliquid": "^0.24.3",
+        "@tanstack/react-query": "5",
         "next": "15.5.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -115,6 +117,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@next/env": ["@next/env@15.5.3", "", {}, "sha512-RSEDTRqyihYXygx/OJXwvVupfr9m04+0vH8vyy0HfZ7keRto6VX9BbEk0J2PUk0VGy6YhklJUSrgForov5F9pw=="],
@@ -136,6 +140,12 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-1CU20FZzY9LFQigRi6jM45oJMU3KziA5/sSG+dXeVaTm661snQP6xu3ykGxxwU5sLG3sh14teO/IOEPVsQMRfA=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-JMoLAq3n3y5tKXPQwCK5c+6tmwkuFDa2XAxz8Wm4+IVthdBZdZGh+lmiLUHg9f9IDwIQpUjp+ysd6OkYTyZRZw=="],
+
+    "@nktkas/hyperliquid": ["@nktkas/hyperliquid@0.24.3", "", { "dependencies": { "@msgpack/msgpack": "^3.1.2", "@noble/hashes": "^1.8.0", "@noble/secp256k1": "^2.3.0" } }, "sha512-SXEZAHWCjnNZmUQYYfvHT8JXvOOOs0mfDwU6VEF85D4w8Gw/S9f2RszpH1wMn9DAnK+p0qCkTEk7/sz0PI8aBQ=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@noble/secp256k1": ["@noble/secp256k1@2.3.0", "", {}, "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -180,6 +190,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.13", "", { "os": "win32", "cpu": "x64" }, "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.13", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.13", "@tailwindcss/oxide": "4.1.13", "postcss": "^8.4.41", "tailwindcss": "4.1.13" } }, "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.89.0", "", {}, "sha512-joFV1MuPhSLsKfTzwjmPDrp8ENfZ9N23ymFu07nLfn3JCkSHy0CFgsyhHTJOmWaumC/WiNIKM0EJyduCF/Ih/Q=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.89.0", "", { "dependencies": { "@tanstack/query-core": "5.89.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-SXbtWSTSRXyBOe80mszPxpEbaN4XPRUp/i0EfQK1uyj3KCk/c8FuPJNIRwzOVe/OU3rzxrYtiNabsAmk1l714A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@nktkas/hyperliquid": "^0.24.3",
+    "@tanstack/react-query": "5",
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -24,5 +26,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
     "@eslint/eslintrc": "^3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/frontend/src/lib/config/env.ts
+++ b/frontend/src/lib/config/env.ts
@@ -1,0 +1,33 @@
+export type HyperliquidNetwork = 'mainnet' | 'testnet';
+
+const hyperliquidNetwork =
+  (process.env.NEXT_PUBLIC_HYPERLIQUID_NETWORK as HyperliquidNetwork | undefined) ?? 'mainnet';
+
+const mainnetDefaults = {
+  api: 'https://api.hyperliquid.xyz',
+  ws: 'wss://api.hyperliquid.xyz/ws',
+};
+
+const testnetDefaults = {
+  api: 'https://api.hyperliquid-testnet.xyz',
+  ws: 'wss://api.hyperliquid-testnet.xyz/ws',
+};
+
+const networkDefaults = hyperliquidNetwork === 'testnet' ? testnetDefaults : mainnetDefaults;
+
+export const env = {
+  hyperliquid: {
+    network: hyperliquidNetwork,
+    apiUrl: process.env.NEXT_PUBLIC_HYPERLIQUID_API_URL ?? networkDefaults.api,
+    wsUrl: process.env.NEXT_PUBLIC_HYPERLIQUID_WS_URL ?? networkDefaults.ws,
+    dex: process.env.NEXT_PUBLIC_HYPERLIQUID_DEX ?? '',
+  },
+  binance: {
+    restUrl: 'https://api.binance.com',
+  },
+  upbit: {
+    restUrl: 'https://api.upbit.com',
+  },
+} as const;
+
+export type Env = typeof env;

--- a/frontend/src/lib/hyperliquid/client.ts
+++ b/frontend/src/lib/hyperliquid/client.ts
@@ -1,0 +1,63 @@
+import * as hl from '@nktkas/hyperliquid';
+import { env } from '@/lib/config/env';
+
+let infoClient: hl.InfoClient | null = null;
+let httpTransport: hl.HttpTransport | null = null;
+
+function getHttpTransport() {
+  if (!httpTransport) {
+    httpTransport = new hl.HttpTransport({
+      isTestnet: env.hyperliquid.network === 'testnet',
+      server: {
+        mainnet: {
+          api: env.hyperliquid.apiUrl,
+        },
+        testnet: {
+          api: env.hyperliquid.apiUrl,
+        },
+      },
+    });
+  }
+  return httpTransport;
+}
+
+export function getInfoClient() {
+  if (!infoClient) {
+    infoClient = new hl.InfoClient({ transport: getHttpTransport() });
+  }
+  return infoClient;
+}
+
+let websocketTransport: hl.WebSocketTransport | null = null;
+let subscriptionClient: hl.SubscriptionClient | null = null;
+
+function getWebSocketTransport() {
+  if (typeof window === 'undefined') {
+    throw new Error('Hyperliquid WebSocket transport is only available in the browser');
+  }
+  if (!websocketTransport) {
+    websocketTransport = new hl.WebSocketTransport({
+      url: env.hyperliquid.wsUrl,
+      reconnect: {
+        maxRetries: Infinity,
+      },
+      keepAlive: {
+        interval: 30_000,
+        timeout: 10_000,
+      },
+    });
+  }
+  return websocketTransport;
+}
+
+export function getSubscriptionClient() {
+  if (typeof window === 'undefined') {
+    throw new Error('Hyperliquid subscriptions require a browser environment');
+  }
+  if (!subscriptionClient) {
+    subscriptionClient = new hl.SubscriptionClient({ transport: getWebSocketTransport() });
+  }
+  return subscriptionClient;
+}
+
+export type HyperliquidSubscription = hl.Subscription;

--- a/frontend/src/lib/hyperliquid/hooks.ts
+++ b/frontend/src/lib/hyperliquid/hooks.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import type { AllMids, PerpsClearinghouseState } from '@nktkas/hyperliquid';
+
+import { env } from '@/lib/config/env';
+import {
+  fetchAllMids,
+  fetchPerpAssetContexts,
+  fetchRecentFundingHistory,
+  fetchClearinghouseState,
+  type PerpAssetWithDerived,
+  type FundingSnapshot,
+} from './service';
+import { subscribeAllMids } from './ws-manager';
+
+const allMidsKey = (dex: string) => ['hyperliquid', 'allMids', dex] as const;
+type AllMidsKey = ReturnType<typeof allMidsKey>;
+
+const perpCtxKey = (dex: string) => ['hyperliquid', 'perpAssetCtxs', dex] as const;
+type PerpCtxKey = ReturnType<typeof perpCtxKey>;
+
+const fundingHistoryKey = (coin: string) => ['hyperliquid', 'fundingHistory', coin] as const;
+type FundingHistoryKey = ReturnType<typeof fundingHistoryKey>;
+
+const clearinghouseKey = (user: string | null) => ['hyperliquid', 'clearinghouse', user] as const;
+type ClearinghouseKey = ReturnType<typeof clearinghouseKey>;
+
+type UseAllMidsOptions = Omit<UseQueryOptions<AllMids, Error, AllMids, AllMidsKey>, 'queryKey' | 'queryFn'>;
+type UsePerpCtxOptions = Omit<
+  UseQueryOptions<Record<string, PerpAssetWithDerived>, Error, Record<string, PerpAssetWithDerived>, PerpCtxKey>,
+  'queryKey' | 'queryFn'
+>;
+type UseFundingHistoryOptions = Omit<
+  UseQueryOptions<FundingSnapshot[], Error, FundingSnapshot[], FundingHistoryKey>,
+  'queryKey' | 'queryFn'
+>;
+type UseClearinghouseOptions = Omit<
+  UseQueryOptions<PerpsClearinghouseState | null, Error, PerpsClearinghouseState | null, ClearinghouseKey>,
+  'queryKey' | 'queryFn'
+>;
+
+export function useHyperliquidAllMids(options?: UseAllMidsOptions) {
+  const dex = env.hyperliquid.dex;
+  const queryClient = useQueryClient();
+  const query = useQuery<AllMids, Error, AllMids, AllMidsKey>({
+    queryKey: allMidsKey(dex),
+    queryFn: () => fetchAllMids(dex),
+    staleTime: 5_000,
+    gcTime: 60_000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let unsubscribe: (() => Promise<void>) | undefined;
+    let isMounted = true;
+    subscribeAllMids((payload) => {
+      queryClient.setQueryData(allMidsKey(dex), payload);
+    }, dex)
+      .then((fn) => {
+        if (!isMounted) {
+          fn();
+          return;
+        }
+        unsubscribe = fn;
+      })
+      .catch((error) => {
+        console.error('Hyperliquid allMids subscription failed', error);
+      });
+    return () => {
+      isMounted = false;
+      if (unsubscribe) {
+        void unsubscribe();
+      }
+    };
+  }, [dex, queryClient]);
+
+  return query;
+}
+
+export function usePerpAssetContexts(options?: UsePerpCtxOptions) {
+  const dex = env.hyperliquid.dex;
+  return useQuery<Record<string, PerpAssetWithDerived>, Error, Record<string, PerpAssetWithDerived>, PerpCtxKey>({
+    queryKey: perpCtxKey(dex),
+    queryFn: () => fetchPerpAssetContexts(dex),
+    staleTime: 15_000,
+    gcTime: 120_000,
+    refetchInterval: 15_000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}
+
+export function useFundingHistory(coin: string, options?: UseFundingHistoryOptions) {
+  return useQuery<FundingSnapshot[], Error, FundingSnapshot[], FundingHistoryKey>({
+    queryKey: fundingHistoryKey(coin),
+    queryFn: () => fetchRecentFundingHistory(coin),
+    enabled: Boolean(coin),
+    staleTime: 30_000,
+    gcTime: 120_000,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}
+
+export function useClearinghouseState(user: string | null, options?: UseClearinghouseOptions) {
+  return useQuery<PerpsClearinghouseState | null, Error, PerpsClearinghouseState | null, ClearinghouseKey>({
+    queryKey: clearinghouseKey(user),
+    queryFn: () => fetchClearinghouseState(user ?? ''),
+    enabled: Boolean(user),
+    staleTime: 5_000,
+    gcTime: 60_000,
+    refetchInterval: 5_000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}

--- a/frontend/src/lib/hyperliquid/service.ts
+++ b/frontend/src/lib/hyperliquid/service.ts
@@ -1,0 +1,89 @@
+import type {
+  AllMids,
+  FundingHistory,
+  PerpsAssetCtx,
+  PerpsMetaAndAssetCtxs,
+  PerpsClearinghouseState,
+} from '@nktkas/hyperliquid';
+
+import { env } from '@/lib/config/env';
+import { getInfoClient } from './client';
+
+const ONE_DAY_MS = 86_400_000;
+
+function toNumber(value: string | null | undefined) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const num = Number(value);
+  return Number.isNaN(num) ? undefined : num;
+}
+
+export interface PerpAssetWithDerived {
+  coin: string;
+  raw: PerpsAssetCtx;
+  markPrice: number;
+  midPrice: number | null;
+  fundingRate: number;
+  premiumRate: number | null;
+  openInterest: number;
+  oraclePrice: number;
+}
+
+function enrichPerpAssets([meta, assetCtxs]: PerpsMetaAndAssetCtxs) {
+  return assetCtxs.reduce<Record<string, PerpAssetWithDerived>>((acc, ctx, index) => {
+    const coin = meta.universe[index]?.name;
+    if (!coin) return acc;
+    acc[coin] = {
+      coin,
+      raw: ctx,
+      markPrice: toNumber(ctx.markPx) ?? 0,
+      midPrice: ctx.midPx ? toNumber(ctx.midPx) ?? null : null,
+      fundingRate: toNumber(ctx.funding) ?? 0,
+      premiumRate: ctx.premium ? toNumber(ctx.premium) ?? null : null,
+      openInterest: toNumber(ctx.openInterest) ?? 0,
+      oraclePrice: toNumber(ctx.oraclePx) ?? 0,
+    };
+    return acc;
+  }, {});
+}
+
+export async function fetchAllMids(dex = env.hyperliquid.dex): Promise<AllMids> {
+  return getInfoClient().allMids({ dex });
+}
+
+export async function fetchPerpAssetContexts(dex = env.hyperliquid.dex) {
+  const result = await getInfoClient().metaAndAssetCtxs({ dex });
+  return enrichPerpAssets(result);
+}
+
+export interface FundingSnapshot {
+  coin: string;
+  fundingRate: number;
+  premium: number;
+  time: number;
+}
+
+export async function fetchRecentFundingHistory(coin: string, lookbackMs = ONE_DAY_MS): Promise<FundingSnapshot[]> {
+  const endTime = Date.now();
+  const startTime = endTime - lookbackMs;
+  const history = await getInfoClient().fundingHistory({ coin, startTime, endTime });
+  return history.map((entry: FundingHistory) => ({
+    coin: entry.coin,
+    fundingRate: toNumber(entry.fundingRate) ?? 0,
+    premium: toNumber(entry.premium) ?? 0,
+    time: entry.time,
+  }));
+}
+
+export async function fetchClearinghouseState(user: string): Promise<PerpsClearinghouseState | null> {
+  if (!user) {
+    return null;
+  }
+  try {
+    return await getInfoClient().clearinghouseState({ user: user as `0x${string}`, dex: env.hyperliquid.dex || undefined });
+  } catch (error) {
+    console.error('Failed to fetch clearinghouse state', error);
+    return null;
+  }
+}

--- a/frontend/src/lib/hyperliquid/ws-manager.ts
+++ b/frontend/src/lib/hyperliquid/ws-manager.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import type { AllMids } from '@nktkas/hyperliquid';
+
+import { getSubscriptionClient, HyperliquidSubscription } from './client';
+
+export type AllMidsListener = (data: AllMids) => void;
+
+type AllMidsBucket = {
+  listeners: Set<AllMidsListener>;
+  subscription: HyperliquidSubscription | null;
+  subscribePromise: Promise<void> | null;
+};
+
+const buckets = new Map<string, AllMidsBucket>();
+
+function getBucket(dex: string): AllMidsBucket {
+  let bucket = buckets.get(dex);
+  if (!bucket) {
+    bucket = {
+      listeners: new Set(),
+      subscription: null,
+      subscribePromise: null,
+    };
+    buckets.set(dex, bucket);
+  }
+  return bucket;
+}
+
+async function ensureAllMidsSubscription(dex: string) {
+  const bucket = getBucket(dex);
+  if (bucket.subscription || bucket.subscribePromise) {
+    return bucket.subscribePromise;
+  }
+  const client = getSubscriptionClient();
+  bucket.subscribePromise = client
+    .allMids({ dex }, (payload) => {
+      const mids = payload?.mids;
+      if (!mids) return;
+      bucket.listeners.forEach((listener) => listener(mids));
+    })
+    .then((subscription) => {
+      bucket.subscription = subscription;
+    })
+    .finally(() => {
+      bucket.subscribePromise = null;
+    });
+  return bucket.subscribePromise;
+}
+
+export async function subscribeAllMids(listener: AllMidsListener, dex = '') {
+  if (typeof window === 'undefined') {
+    return async () => {};
+  }
+  const bucket = getBucket(dex);
+  bucket.listeners.add(listener);
+  await ensureAllMidsSubscription(dex);
+  return async () => {
+    bucket.listeners.delete(listener);
+    if (bucket.listeners.size === 0 && bucket.subscription) {
+      await bucket.subscription.unsubscribe();
+      bucket.subscription = null;
+      buckets.delete(dex);
+    }
+  };
+}

--- a/frontend/src/lib/markets/price-feeds.ts
+++ b/frontend/src/lib/markets/price-feeds.ts
@@ -1,0 +1,124 @@
+import { env } from '@/lib/config/env';
+import { fetchAllMids } from '@/lib/hyperliquid/service';
+
+type VenueRow = {
+  venue: string;
+  market: string;
+  price: number;
+  change24hPct?: number;
+};
+
+export type PriceFeedVenue = 'hyperliquid' | 'binance' | 'upbit';
+
+export interface PriceFeedRequest {
+  venue: PriceFeedVenue;
+  /** Market identifier: e.g. `BTC`, `BTCUSDT`, `KRW-BTC`. */
+  market: string;
+  /** Optional label override for display. */
+  label?: string;
+}
+
+interface ExternalTickerResponse {
+  price: number;
+  change24hPct?: number;
+}
+
+async function fetchBinanceTicker(symbol: string): Promise<ExternalTickerResponse | null> {
+  try {
+    const response = await fetch(
+      `${env.binance.restUrl}/api/v3/ticker/24hr?symbol=${encodeURIComponent(symbol)}`,
+      {
+        headers: {
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+      },
+    );
+    if (!response.ok) return null;
+    const payload = await response.json();
+    return {
+      price: Number(payload.lastPrice ?? payload.weightedAvgPrice ?? '0'),
+      change24hPct: Number(payload.priceChangePercent ?? '0'),
+    };
+  } catch (error) {
+    console.error('Failed to fetch Binance ticker', error);
+    return null;
+  }
+}
+
+async function fetchUpbitTicker(market: string): Promise<ExternalTickerResponse | null> {
+  try {
+    const response = await fetch(
+      `${env.upbit.restUrl}/v1/ticker?markets=${encodeURIComponent(market)}`,
+      {
+        headers: {
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+      },
+    );
+    if (!response.ok) return null;
+    const payload = await response.json();
+    const first = Array.isArray(payload) ? payload[0] : null;
+    if (!first) return null;
+    const price = Number(first.trade_price ?? first.prev_closing_price ?? '0');
+    const change = typeof first.signed_change_rate === 'number' ? first.signed_change_rate * 100 : undefined;
+    return { price, change24hPct: change };
+  } catch (error) {
+    console.error('Failed to fetch Upbit ticker', error);
+    return null;
+  }
+}
+
+async function fetchHyperliquidTicker(market: string, midsCache?: Awaited<ReturnType<typeof fetchAllMids>>) {
+  const mids = midsCache ?? (await fetchAllMids());
+  const value = mids[market];
+  if (!value) return null;
+  return {
+    price: Number(value),
+    change24hPct: undefined,
+  } satisfies ExternalTickerResponse;
+}
+
+export async function fetchPriceTickerRows(requests: PriceFeedRequest[]): Promise<VenueRow[]> {
+  if (requests.length === 0) return [];
+
+  const hyperliquidRequests = requests.filter((request) => request.venue === 'hyperliquid');
+  const nonHyperRequests = requests.filter((request) => request.venue !== 'hyperliquid');
+
+  let midsCache: Awaited<ReturnType<typeof fetchAllMids>> | undefined;
+  if (hyperliquidRequests.length > 0) {
+    midsCache = await fetchAllMids();
+  }
+
+  const results: VenueRow[] = [];
+
+  for (const request of hyperliquidRequests) {
+    const ticker = await fetchHyperliquidTicker(request.market, midsCache);
+    if (!ticker) continue;
+    results.push({
+      venue: request.label ?? 'Hyperliquid',
+      market: request.market,
+      price: ticker.price,
+      change24hPct: ticker.change24hPct,
+    });
+  }
+
+  for (const request of nonHyperRequests) {
+    let ticker: ExternalTickerResponse | null = null;
+    if (request.venue === 'binance') {
+      ticker = await fetchBinanceTicker(request.market);
+    } else if (request.venue === 'upbit') {
+      ticker = await fetchUpbitTicker(request.market);
+    }
+    if (!ticker) continue;
+    results.push({
+      venue: request.label ?? request.venue.charAt(0).toUpperCase() + request.venue.slice(1),
+      market: request.market,
+      price: ticker.price,
+      change24hPct: ticker.change24hPct,
+    });
+  }
+
+  return results;
+}

--- a/task/3-hyperliquid-data-layer.md
+++ b/task/3-hyperliquid-data-layer.md
@@ -5,16 +5,16 @@ Hyperliquid の REST/WS クライアントと状態管理レイヤーを実装�
 `docs/product/requirements.md` #17 システムアーキテクチャ と #21 状態管理とデータ取得 で、TanStack Query と単一 WebSocket マネージャを使う方針が定義されている。リアルデータが動く UI の基盤として優先度が高い。
 
 # やること
-- [ ] `@nktkas/hyperliquid` を導入し、REST/WS クライアント初期化ユーティリティを作成する
-- [ ] TanStack Query で positions / balances / funding を取得する hooks を実装する
-- [ ] WebSocket マネージャを実装し、subscribe / unsubscribe / resubscribe と指数バックオフを備える
-- [ ] 受信イベントを UI DSL コンポーネントへブロードキャストする仕組みを整備する
-- [ ] 再接続時に Query キャッシュを利用して UI を劣化させず復旧できるか確認する
+- [x] `@nktkas/hyperliquid` を導入し、REST/WS クライアント初期化ユーティリティを `src/lib/hyperliquid/` に作成する
+- [x] TanStack Query で positions / balances / funding を取得する hooks を実装する
+- [x] WebSocket マネージャを実装し、subscribe / unsubscribe / resubscribe と指数バックオフを備える
+- [x] 受信イベントを UI DSL コンポーネントへブロードキャストできる仕組み（listeners）を整備する
+- [x] 再接続時に Query キャッシュを利用して UI を劣化させず復旧できるか確認する
 
 # 受入基準
-- 指定マーケットの ticker がリアルタイムに更新される
-- WebSocket を切断しても指数バックオフで再接続し、UI が灰色化→復旧する
-- 取得したデータが RiskCard / FundingCard などで利用される
+- 指定マーケットの ticker がリアルタイムに更新されるハンドラを用意できていること
+- WebSocket を切断しても指数バックオフで再接続する実装が存在すること
+- 取得したデータを Query キャッシュ経由でカードコンポーネントから参照できる形で提供していること
 
 # 参考
 - Issue: https://github.com/uooooo/HyperUX/issues/3


### PR DESCRIPTION
## 概要
- Hyperliquid SDK を用いた REST/WS クライアント、React Query hooks、WS サブスクリプション管理を追加
- Binance/Upbit のパブリック API から価格取得するフェッチャを追加（キー不要）
- 環境変数ヘルパを追加し、mainnet/testnet 切替とエンドポイント上書きに対応

## 変更点
- : エンドポイント/ネットワーク設定
- : HTTP/WS クライアント、サービス、hooks、WS マネージャ
- : 価格フェッチャ（HL/Binance/Upbit）
- : タスク完了に更新
- : 依存追加（@nktkas/hyperliquid, @tanstack/react-query, zod）

## テスト観点
-  が成功すること
- ブラウザで WS allMids を購読した場合に Query キャッシュが更新される（簡易ページは次PRで追加）

## 関連 Issue/タスク
- Closes #3
