### PR TITLE
feat(pages): scaffold Home, Market, KPI bar (#6)

### DIFF
--- a/frontend/src/app/market/page.tsx
+++ b/frontend/src/app/market/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+import { sampleBundles } from '@/lib/ui-dsl/samples';
+
+export default function MarketPage() {
+  const entries = Object.entries(sampleBundles);
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-16 text-white/80">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-white">Market</h1>
+        <p className="text-sm text-white/60">Registered UIs (mock)</p>
+      </header>
+      <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {entries.map(([hash, dsl]) => (
+          <li key={hash} className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <div className="mb-2 text-sm uppercase tracking-wide text-white/50">{dsl.persona}</div>
+            <div className="mb-1 text-lg font-semibold text-white">{dsl.name}</div>
+            <div className="mb-2 text-xs text-white/60">BundleHash: <code className="bg-white/10 px-1 py-0.5 rounded">{hash}</code></div>
+            <div className="mb-3 text-xs text-white/60">Author: demo · Split: {process.env.NEXT_PUBLIC_HYPERLIQUID_DEFAULT_SPLIT_ADDRESS ?? 'mock'}</div>
+            <div className="flex justify-between text-sm">
+              <Link className="text-white/80 hover:underline" href={`/t/${hash}`}>
+                Preview →
+              </Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,103 +1,58 @@
-import Image from "next/image";
+"use client";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { sampleBundles } from "@/lib/ui-dsl/samples";
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const router = useRouter();
+  const [bundleHash, setBundleHash] = useState<string>("bundle-scalp-momentum");
+  const [prompt, setPrompt] = useState<string>("");
+  const bundles = useMemo(() => Object.entries(sampleBundles), []);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    // For MVP, ignore prompt and route to selected sample bundle
+    router.push(`/t/${bundleHash}`);
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-16 text-white/80">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-white">HyperUX</h1>
+        <p className="text-sm text-white/60">Prompt → UI → Trade, on Hyperliquid</p>
+      </header>
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <label className="text-sm text-white/70">Prompt</label>
+        <textarea
+          className="min-h-[120px] rounded-md border border-white/10 bg-white/5 p-3 text-sm outline-none focus:ring-2 focus:ring-white/20"
+          placeholder="e.g. BTC 3x scalp layout with quick actions and risk card"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+        <label className="text-sm text-white/70">Sample bundle (for demo)</label>
+        <select
+          value={bundleHash}
+          onChange={(e) => setBundleHash(e.target.value)}
+          className="w-full rounded-md border border-white/10 bg-white/5 p-2 text-sm"
+        >
+          {bundles.map(([hash, dsl]) => (
+            <option key={hash} value={hash}>
+              {dsl.name} ({hash})
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            className="rounded-md bg-white/90 px-4 py-2 text-sm font-medium text-black hover:bg-white"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
+            Generate & Trade
+          </button>
+          <a href="/market" className="rounded-md border border-white/20 px-4 py-2 text-sm text-white/80 hover:bg-white/5">
+            Market →
           </a>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      </form>
+    </main>
   );
 }

--- a/frontend/src/app/t/[bundleHash]/page.tsx
+++ b/frontend/src/app/t/[bundleHash]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import UiDslRenderer from '@/components/ui-dsl/renderer';
+import KpiBar from '@/components/kpi-bar';
 import { sampleBundles } from '@/lib/ui-dsl/samples';
 
 interface PageProps {
@@ -39,8 +40,11 @@ export default function BundlePreviewPage({ params }: PageProps) {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-16 text-white/80">
-      <header className="space-y-2">
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-6 py-8 text-white/80">
+      <header className="sticky top-0 z-10 -mx-6 mb-4 border-b border-white/10 bg-black/60 px-6 py-3 backdrop-blur">
+        <KpiBar />
+      </header>
+      <header className="space-y-2 mt-4">
         <p className="text-xs uppercase tracking-wide text-white/50">Persona · {dsl.persona}</p>
         <h1 className="text-3xl font-semibold text-white">{dsl.name}</h1>
         {dsl.description ? <p className="text-sm text-white/60">{dsl.description}</p> : null}

--- a/frontend/src/components/kpi-bar.tsx
+++ b/frontend/src/components/kpi-bar.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function KpiBar() {
+  const [ttv, setTtv] = useState(0);
+  useEffect(() => {
+    const start = performance.now();
+    const id = setTimeout(() => setTtv(Math.round(performance.now() - start)), 0);
+    return () => clearTimeout(id);
+  }, []);
+  return (
+    <div className="flex items-center justify-between text-xs text-white/70">
+      <div>TTV: {ttv} ms</div>
+      <div>WS Reconnects: 0</div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
概要
- Issue #6: ページの足場を実装（Home → /t/[bundleHash]、/market、KPIバー）。UI DSL と既存のレンダラーを結線し、動くデモを最小で成立。

変更点
- Home (`src/app/page.tsx`):
  - クライアントフォーム（Prompt入力＋サンプルBundle選択）→ `/t/[bundleHash]` へ遷移
- Market (`src/app/market/page.tsx`):
  - `sampleBundles` を一覧表示（BundleHash/作者/Splitを表示、Previewリンク）
- Trade (`src/app/t/[bundleHash]/page.tsx`):
  - Sticky KPIバーコンポーネントを追加（TTV/再接続のプレースホルダ）
  - 既存 `UiDslRenderer` でDSLを描画
- Components: `src/components/kpi-bar.tsx`（Client Component）

受入基準
- 3ページに遷移可能でエラーなし
- Homeから送信→Tradeで選択DSLが表示
- MarketでBundleHash/作者/Splitが確認できる

テスト
- `bun run lint` / `bun run build` パス

関連Issue/タスク
- Closes #6
- 追加で作成: #11, #12, #13, #14（Post-#6 のネクストアクション）
