### PR TITLE
feat(ui): enable scalper and dca trading (#17)

### DIFF
--- a/frontend/src/app/t/[bundleHash]/page.tsx
+++ b/frontend/src/app/t/[bundleHash]/page.tsx
@@ -4,6 +4,8 @@ import UiDslRenderer from '@/components/ui-dsl/renderer';
 import KpiBar from '@/components/kpi-bar';
 import { sampleBundles } from '@/lib/ui-dsl/samples';
 
+import { TradeBundleProvider } from '@/context/trade-bundle';
+
 interface PageProps {
   params: { bundleHash: string };
 }
@@ -39,22 +41,24 @@ export default function BundlePreviewPage({ params }: PageProps) {
   }
 
   return (
-    <main className="mx-auto flex min-h-[calc(100vh-72px)] max-w-6xl flex-col gap-10 px-6 py-10 text-[var(--color-text-secondary)]">
-      <header className="flex flex-col gap-6">
-        <div className="flex flex-col gap-3">
-          <p className="text-xs uppercase tracking-[0.4em] text-[var(--color-text-muted)]">Persona · {dsl.persona}</p>
-          <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
-            <h1 className="text-3xl font-semibold text-[var(--color-text-primary)]">{dsl.name}</h1>
-            {dsl.description ? <p className="max-w-xl text-sm text-[var(--color-text-secondary)]">{dsl.description}</p> : null}
+    <TradeBundleProvider bundleHash={params.bundleHash}>
+      <main className="mx-auto flex min-h-[calc(100vh-72px)] max-w-6xl flex-col gap-10 px-6 py-10 text-[var(--color-text-secondary)]">
+        <header className="flex flex-col gap-6">
+          <div className="flex flex-col gap-3">
+            <p className="text-xs uppercase tracking-[0.4em] text-[var(--color-text-muted)]">Persona · {dsl.persona}</p>
+            <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
+              <h1 className="text-3xl font-semibold text-[var(--color-text-primary)]">{dsl.name}</h1>
+              {dsl.description ? <p className="max-w-xl text-sm text-[var(--color-text-secondary)]">{dsl.description}</p> : null}
+            </div>
           </div>
-        </div>
-        <div className="rounded-3xl border border-[var(--color-border)] bg-[rgba(4,20,17,0.75)] px-6 py-4 shadow-[var(--shadow-card)]">
-          <KpiBar />
-        </div>
-      </header>
-      <section className="space-y-6">
-        <UiDslRenderer dsl={dsl} />
-      </section>
-    </main>
+          <div className="rounded-3xl border border-[var(--color-border)] bg-[rgba(4,20,17,0.75)] px-6 py-4 shadow-[var(--shadow-card)]">
+            <KpiBar />
+          </div>
+        </header>
+        <section className="space-y-6">
+          <UiDslRenderer dsl={dsl} />
+        </section>
+      </main>
+    </TradeBundleProvider>
   );
 }

--- a/frontend/src/components/ui-dsl/renderer.tsx
+++ b/frontend/src/components/ui-dsl/renderer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties } from 'react';
 import { uiDslSchema } from '@/lib/ui-dsl/schema';
 import type { UiComponent, UiDsl } from '@/lib/ui-dsl/types';

--- a/frontend/src/context/trade-bundle.tsx
+++ b/frontend/src/context/trade-bundle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+interface TradeBundleContextValue {
+  bundleHash: string;
+}
+
+const TradeBundleContext = createContext<TradeBundleContextValue | null>(null);
+
+export function TradeBundleProvider({ bundleHash, children }: { bundleHash: string; children: ReactNode }) {
+  return <TradeBundleContext.Provider value={{ bundleHash }}>{children}</TradeBundleContext.Provider>;
+}
+
+export function useTradeBundle() {
+  const context = useContext(TradeBundleContext);
+  if (!context) {
+    throw new Error('useTradeBundle must be used within a TradeBundleProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/use-place-order.ts
+++ b/frontend/src/hooks/use-place-order.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useAccount } from 'wagmi';
+
+import { useTradeBundle } from '@/context/trade-bundle';
+
+export type PlaceOrderInput = {
+  market: string;
+  side: 'buy' | 'sell';
+  price: number;
+  sizeUsd: number;
+  reduceOnly?: boolean;
+  timeInForce?: 'Gtc' | 'Ioc' | 'Alo';
+  clientId?: `0x${string}`;
+};
+
+async function submitOrder(
+  bundleHash: string,
+  walletAddress: string,
+  order: PlaceOrderInput,
+) {
+  if (!order.market) {
+    throw new Error('Missing market symbol');
+  }
+  if (!(order.price > 0) || !(order.sizeUsd > 0)) {
+    throw new Error('Price and sizeUsd must be positive');
+  }
+
+  const idempotencyKey = typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
+  const response = await fetch('/api/order', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-bundle-hash': bundleHash,
+      'x-wallet-address': walletAddress,
+      'x-idempotency-key': idempotencyKey,
+    },
+    body: JSON.stringify({
+      orders: [
+        {
+          market: order.market,
+          side: order.side,
+          price: order.price,
+          sizeUsd: order.sizeUsd,
+          reduceOnly: order.reduceOnly ?? false,
+          timeInForce: order.timeInForce ?? 'Gtc',
+          clientId: order.clientId,
+          orderType: 'limit',
+        },
+      ],
+    }),
+  });
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    if (response.ok) {
+      throw error;
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      (payload && typeof payload === 'object' && 'error' in payload && typeof (payload as { error?: string }).error === 'string'
+        ? (payload as { error: string }).error
+        : 'Order request failed');
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+export function usePlaceOrder() {
+  const { bundleHash } = useTradeBundle();
+  const { address } = useAccount();
+
+  return useMutation({
+    mutationKey: ['placeOrder', bundleHash, address],
+    mutationFn: async (order: PlaceOrderInput) => {
+      if (!address) {
+        throw new Error('Connect wallet to trade');
+      }
+      return submitOrder(bundleHash, address, order);
+    },
+  });
+}

--- a/frontend/src/hooks/use-redstone-price.ts
+++ b/frontend/src/hooks/use-redstone-price.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { fetchRedstonePrice, type RedstonePrice } from '@/lib/markets/redstone';
+
+type UseRedstonePriceOptions = Omit<UseQueryOptions<RedstonePrice | null, Error, RedstonePrice | null>, 'queryKey' | 'queryFn'>;
+
+export function useRedstonePrice(symbol: string, options?: UseRedstonePriceOptions) {
+  return useQuery({
+    queryKey: ['redstone', symbol],
+    queryFn: () => fetchRedstonePrice(symbol),
+    enabled: Boolean(symbol),
+    staleTime: 30_000,
+    gcTime: 60_000,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}

--- a/frontend/src/lib/hyperliquid/utils.ts
+++ b/frontend/src/lib/hyperliquid/utils.ts
@@ -1,0 +1,10 @@
+export function normalizePerpMarketSymbol(raw: string) {
+  const upper = raw.toUpperCase();
+  if (upper.endsWith('-PERP')) {
+    return upper.replace('-PERP', '');
+  }
+  if (upper.endsWith('USDT')) {
+    return upper.slice(0, -4);
+  }
+  return upper;
+}

--- a/frontend/src/lib/markets/redstone.ts
+++ b/frontend/src/lib/markets/redstone.ts
@@ -1,0 +1,35 @@
+const REDSTONE_ENDPOINT = 'https://api.redstone.finance/prices';
+
+export interface RedstonePrice {
+  symbol: string;
+  value: number;
+  timestamp: number;
+}
+
+export async function fetchRedstonePrice(symbol: string): Promise<RedstonePrice | null> {
+  try {
+    const url = `${REDSTONE_ENDPOINT}?symbols=${encodeURIComponent(symbol)}`;
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      console.error('Redstone price request failed', response.status, response.statusText);
+      return null;
+    }
+
+    const payload = await response.json();
+    const entry = payload?.[symbol];
+    if (!entry || typeof entry.value !== 'number') return null;
+
+    return {
+      symbol,
+      value: entry.value,
+      timestamp: entry.timestamp ?? Date.now(),
+    };
+  } catch (error) {
+    console.error('Failed to fetch Redstone price', error);
+    return null;
+  }
+}

--- a/task/16-delta-neutral-dashboard.md
+++ b/task/16-delta-neutral-dashboard.md
@@ -1,0 +1,23 @@
+# 概要
+Delta Neutral Monitor のダッシュボードに実データ（Hyperliquid + Redstone）とチャートを接続し、ポジションのヘッジ調整を行えるようにする。
+
+# 背景
+Issue #17 の派生タスク。ETH Scalping と BTC DCA については UI から `/api/order` を介した実注文が可能になったが、Delta Neutral Monitor は依然としてモック値のまま。`docs/product/requirements.md` #4 UI/UX 要件と #6 外部API/SDK 仕様では、ポジション管理・Funding 表示・再平衡トリガの実装が必須とされている。また ETH scalping 用チャートは仮置きのままのため、軽量チャートの導入をこのタスクでまとめて扱う。
+
+# やること
+- [ ] `DeltaNeutralDashboardCard` に Hyperliquid ポジション情報をバインドし、spot/perpの delta・PnL・Funding をリアルタイム表示する
+- [ ] 再平衡／クローズ操作から `/api/order` を呼び出せるようにし、両建てのサイズ計算ユーティリティを追加する
+- [ ] Redstone を用いたスポット価格フォールバックを実装し、価格乖離が大きい場合に警告バナーを表示する
+- [ ] Lightweight Charts を導入し、Scalper/DeltaNeutral 双方で簡易チャートを表示できるチャートコンポーネントを実装する
+- [ ] KPI バーへ Delta Neutral 再接続統計・Funding APR を反映できるようフックを拡張する
+
+# 受入基準
+- Delta Neutral ダッシュボードがライブデータで更新され、再平衡・クローズボタンからサーバ経由の注文が成功する
+- 価格データが取得できない、または大きく乖離している場合にユーザーへ警告が表示される
+- `/t/[bundleHash]` の ETH Scalping と Delta Neutral カードでチャートが実際の価格を描画する
+
+# 参考
+- Issue: https://github.com/uooooo/HyperUX/issues/17
+- `docs/product/requirements.md` #4, #6, #21
+- `frontend/src/components/ui-dsl/cards.tsx`
+- `frontend/src/lib/hyperliquid/hooks.ts`


### PR DESCRIPTION
## 概要
- Scalper / DCA ダッシュボードをリアル注文フローへ接続
- Hyperliquid と Redstone のフックを整備し、UI から直接 `/api/order` を叩けるようにした
- Delta Neutral + チャート連携のフォローアップタスクを追加

## 変更点
- `frontend/src/context/trade-bundle.tsx` で bundleHash をコンテキスト化し、クライアントから送るリクエストヘッダに反映
- `use-place-order`, `use-redstone-price`, Hyperliquid ユーティリティなどの新規フックを追加
- `frontend/src/components/ui-dsl/cards.tsx` の ETH Scalper / BTC DCA カードをライブデータ & 注文可能な UI に更新
- `task/16-delta-neutral-dashboard.md` を追加して残タスクを整理

## 影響範囲
- `/t/[bundleHash]` の ETH Scalping / BTC DCA バンドル（UI から実オーダー送出）
- `/api/order` へ送るヘッダ必須化（bundleHash・walletAddress・idempotency）
- React Query キャッシュに Hyperliquid / Redstone データが常駐

## テスト観点
- `bun run lint`
- `bun run build`（Next.js は成功ログを出力。CLI は 13.5s タイムアウトしたので必要なら再実行）

## 関連 Issue / タスク
- Closes #17
- Follow-up: `task/16-delta-neutral-dashboard.md`

## スクショ / ログ
- （必要に応じて追加してください）
